### PR TITLE
Sizing changes

### DIFF
--- a/Tower/tower.tscn
+++ b/Tower/tower.tscn
@@ -35,6 +35,7 @@ sources/0 = SubResource("TileSetAtlasSource_jv8mv")
 size = Vector2(38, 7)
 
 [node name="Tower_Space" type="Node2D"]
+scale = Vector2(10, 10)
 
 [node name="TileMap" type="TileMap" parent="."]
 tile_set = SubResource("TileSet_jqmeu")

--- a/gamemap/gamemap.tscn
+++ b/gamemap/gamemap.tscn
@@ -35,6 +35,7 @@ sources/0 = SubResource("TileSetAtlasSource_jv8mv")
 size = Vector2(38, 8)
 
 [node name="Game_Space" type="Node2D"]
+scale = Vector2(10, 10)
 
 [node name="TileMap" type="TileMap" parent="."]
 tile_set = SubResource("TileSet_jqmeu")

--- a/player/player.tscn
+++ b/player/player.tscn
@@ -20,6 +20,7 @@ shape = SubResource("CircleShape2D_sg52c")
 
 [node name="Camera2D" type="Camera2D" parent="."]
 scale = Vector2(0.24, 0.24)
+zoom = Vector2(0.5, 0.5)
 
 [node name="AttackTimer" type="Timer" parent="."]
 wait_time = 0.5

--- a/world/world.tscn
+++ b/world/world.tscn
@@ -7,12 +7,13 @@
 [node name="PlayerTesting" type="Node2D"]
 
 [node name="Player" parent="." instance=ExtResource("1_5kal6")]
-position = Vector2(487, -170)
-scale = Vector2(0.16, 0.16)
+position = Vector2(-2, 1)
+scale = Vector2(1, 1)
 MAX_SPEED = 600
 FRICTION = 5000
 
 [node name="Game_Space" parent="." instance=ExtResource("2_ueur2")]
+position = Vector2(13, 39)
 
 [node name="Tower_Space" parent="." instance=ExtResource("3_d4x4x")]
-position = Vector2(486, -173)
+position = Vector2(3230, 40)


### PR DESCRIPTION
Increased the size of both maps within their respective scenes by 10x. Player node in world scene reset to scale of 1 (was 0.16). Camera node zoom in player scene halved. These scaling changes gives more room in each map, while keeping the player node visually smaller in game.